### PR TITLE
allow using foreign exchange rates from BNR

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -249,6 +249,105 @@ files = [
 pycparser = "*"
 
 [[package]]
+name = "charset-normalizer"
+version = "3.3.2"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-win32.whl", hash = "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-win32.whl", hash = "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-win32.whl", hash = "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-win32.whl", hash = "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
+    {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
+]
+
+[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -1087,6 +1186,23 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-responses"
+version = "0.5.1"
+description = "py.test integration for responses"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytest_responses-0.5.1-py2.py3-none-any.whl", hash = "sha256:4172e565b94ac1ea3b10aba6e40855ad60cd7f141476b2d8a47e4b5f250be734"},
+]
+
+[package.dependencies]
+pytest = ">=2.5"
+responses = "*"
+
+[package.extras]
+tests = ["flake8"]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1099,6 +1215,105 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.1"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
+    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
+    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
+    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
+    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
+    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
+    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
+    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
+    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
+    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
+    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
+    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
+    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
+    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
+    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+description = "Python HTTP for Humans."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+]
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<4"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<3"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "responses"
+version = "0.25.0"
+description = "A utility library for mocking out the `requests` Python library."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "responses-0.25.0-py3-none-any.whl", hash = "sha256:2f0b9c2b6437db4b528619a77e5d565e4ec2a9532162ac1a131a83529db7be1a"},
+    {file = "responses-0.25.0.tar.gz", hash = "sha256:01ae6a02b4f34e39bffceb0fc6786b67a25eae919c6368d05eabc8d9576c2a66"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+requests = ">=2.30.0,<3.0"
+urllib3 = ">=1.25.10,<3.0"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli", "tomli-w", "types-PyYAML", "types-requests"]
 
 [[package]]
 name = "six"
@@ -1178,6 +1393,23 @@ files = [
     {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
     {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
 ]
+
+[[package]]
+name = "urllib3"
+version = "2.2.1"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
+    {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
+]
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+h2 = ["h2 (>=4,<5)"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -1309,4 +1541,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "44a462373136eb016178909495ac0b49a98d55c84025842a49bd565984eeab81"
+content-hash = "4d7f4319b9b35b6180d2ea069456b1e1122a43d2932ba20314182a5e7240130c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ fastapi = "^0.109.2"
 uvicorn = "^0.27.1"
 python-dotenv = "^1.0.0"
 pydantic = "^2.6.2"
+requests = "^2.31.0"
 
 [tool.poetry.group.dev.dependencies]
 httpx = "^0.26.0"
@@ -40,3 +41,5 @@ pytest-cov = "^4.1.0"
 pytest = "^8.0.0"
 mypy = "^1.8.0"
 pylint = "^3.0.3"
+responses = "^0.25.0"
+pytest-responses = "^0.5.1"

--- a/src/invoice_utils/engine/_engine.py
+++ b/src/invoice_utils/engine/_engine.py
@@ -146,6 +146,10 @@ class InvoicingEngine:
             for cube_node in root.findall(".//{http://www.bnr.ro/xsd}Cube"):
                 if cube_node.attrib["date"] == invoice_date_str:
                     date_rates = cube_node
+            if date_rates is None:
+                self._log.info("can't find BNR fx rates for %s", invoice_date_str)
+                return
+
             symbols = set(bnr_rule.get("symbols", []))
             for rate in date_rates.findall("{http://www.bnr.ro/xsd}Rate"):
                 currency = rate.attrib["currency"]

--- a/src/invoice_utils/engine/_engine.py
+++ b/src/invoice_utils/engine/_engine.py
@@ -26,6 +26,9 @@ class InvoicingEngine:
         except JSONDecodeError as ex:
             raise InvoicingInputFormatError(fpath.name) from ex
 
+        self.__init_invoice()
+
+    def __init_invoice(self):
         self.__invoice = {
             "header": {"buyer": {}, "currency": {}, "seller": {}},
             "items": [],
@@ -180,6 +183,7 @@ class InvoicingEngine:
     def process(
         self, invoice_no: int, invoice_date: datetime, items: list[InvoicedItem] = None
     ):
+        self.__init_invoice()
         items = items or []
         header = self.__invoice["header"]
         header["number"] = invoice_no

--- a/src/invoice_utils/engine/_engine.py
+++ b/src/invoice_utils/engine/_engine.py
@@ -128,6 +128,7 @@ class InvoicingEngine:
         currency_info: dict = self.__invoice["header"].get("currency", {})
         currency_info.update({
             "main": "RON",
+            "exchangeRates": {}
         })
         self.__invoice["header"]["currency"] = currency_info
 

--- a/src/invoice_utils/engine/_engine.py
+++ b/src/invoice_utils/engine/_engine.py
@@ -1,6 +1,6 @@
 import json
 import pathlib
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from json import JSONDecodeError
 from logging import getLogger
@@ -138,6 +138,9 @@ class InvoicingEngine:
                 headers={"Accept": "text/xml", "Accept-Encoding": "utf-8"}
             )
             root = ET.fromstring(res.text)
+            days_from_friday = invoice_date.weekday() - 4
+            if days_from_friday > 0:
+                invoice_date = invoice_date - timedelta(days=days_from_friday)
             invoice_date_str = invoice_date.strftime("%Y-%m-%d")
             date_rates = None
             for cube_node in root.findall(".//{http://www.bnr.ro/xsd}Cube"):

--- a/src/invoice_utils/engine/_engine.py
+++ b/src/invoice_utils/engine/_engine.py
@@ -114,7 +114,7 @@ class InvoicingEngine:
             ]
         return result
 
-    def _process_bnr_rule(self, invoice_date: datetime) -> dict:
+    def _process_bnr_rule(self, invoice_date: datetime):
         bnr_rule = next(
             filter(lambda rule: rule.get("type", "") == "bnr-fx-rate", self.__rules),
             None
@@ -125,12 +125,11 @@ class InvoicingEngine:
             f"https://bnr.ro/files/xml/years/nbrfxrates{invoice_date.year}.xml",
             headers={"Accept": "text/xml", "Accept-Encoding": "utf-8"}
         )
-        return {
+        currency_info: dict = self.__invoice["header"].get("currency", {})
+        currency_info.update({
             "main": "RON",
-            "exchangeRates": {
-
-            }
-        }
+        })
+        self.__invoice["header"]["currency"] = currency_info
 
     def _process_currency(self):
         rule = next(

--- a/tests/data/bnr-response-1-item.xml
+++ b/tests/data/bnr-response-1-item.xml
@@ -1,0 +1,46 @@
+<DataSet xmlns="http://www.bnr.ro/xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.bnr.ro/xsd nbrfxrates.xsd">
+    <script/>
+    <Header>
+        <Publisher>National Bank of Romania</Publisher>
+        <PublishingDate>2023-12-29</PublishingDate>
+        <MessageType>DR</MessageType>
+    </Header>
+    <Body>
+        <Subject>Reference rates</Subject>
+        <OrigCurrency>RON</OrigCurrency>
+        <Cube date="2023-01-03">
+            <Rate currency="AED">1.2733</Rate>
+            <Rate currency="AUD">3.1363</Rate>
+            <Rate currency="BGN">2.5193</Rate>
+            <Rate currency="BRL">0.8719</Rate>
+            <Rate currency="CAD">3.4311</Rate>
+            <Rate currency="CHF">4.9834</Rate>
+            <Rate currency="CNY">0.6771</Rate>
+            <Rate currency="CZK">0.2041</Rate>
+            <Rate currency="DKK">0.6625</Rate>
+            <Rate currency="EGP">0.1887</Rate>
+            <Rate currency="EUR">4.9273</Rate>
+            <Rate currency="GBP">5.5720</Rate>
+            <Rate currency="HUF" multiplier="100">1.2218</Rate>
+            <Rate currency="INR">0.0564</Rate>
+            <Rate currency="JPY" multiplier="100">3.5797</Rate>
+            <Rate currency="KRW" multiplier="100">0.3656</Rate>
+            <Rate currency="MDL">0.2407</Rate>
+            <Rate currency="MXN">0.2396</Rate>
+            <Rate currency="NOK">0.4701</Rate>
+            <Rate currency="NZD">2.9077</Rate>
+            <Rate currency="PLN">1.0518</Rate>
+            <Rate currency="RSD">0.0420</Rate>
+            <Rate currency="RUB">0.0641</Rate>
+            <Rate currency="SEK">0.4434</Rate>
+            <Rate currency="THB">0.1358</Rate>
+            <Rate currency="TRY">0.2496</Rate>
+            <Rate currency="UAH">0.1266</Rate>
+            <Rate currency="USD">4.6766</Rate>
+            <Rate currency="XAU">275.9130</Rate>
+            <Rate currency="XDR">6.2220</Rate>
+            <Rate currency="ZAR">0.2737</Rate>
+        </Cube>
+    </Body>
+</DataSet>

--- a/tests/data/bnr-response-1-item.xml
+++ b/tests/data/bnr-response-1-item.xml
@@ -9,7 +9,7 @@
     <Body>
         <Subject>Reference rates</Subject>
         <OrigCurrency>RON</OrigCurrency>
-        <Cube date="2023-01-03">
+        <Cube date="2011-11-11">
             <Rate currency="AED">1.2733</Rate>
             <Rate currency="AUD">3.1363</Rate>
             <Rate currency="BGN">2.5193</Rate>

--- a/tests/data/bnr-response-invalid.xml
+++ b/tests/data/bnr-response-invalid.xml
@@ -1,0 +1,45 @@
+<DataSet xmlns="http://www.bnr.ro/xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.bnr.ro/xsd nbrfxrates.xsd">
+    <script/>
+    <Header>
+        <Publisher>National Bank of Romania</Publisher>
+        <PublishingDate>2023-12-29</PublishingDate>
+        <MessageType>DR</MessageType>
+    </Header>
+    <Body>
+        <Subject>Reference rates</Subject>
+        <OrigCurrency>RON</OrigCurrency>
+        <Cube date="2011-11-11">
+            <Rate currency="AED">1.2733</Rate>
+            <Rate currency="AUD">3.1363</Rate>
+            <Rate currency="BGN">2.5193</Rate>
+            <Rate currency="BRL">0.8719</Rate>
+            <Rate currency="CAD">3.4311</Rate>
+            <Rate currency="CHF">4.9834</Rate>
+            <Rate currency="CNY">0.6771</Rate>
+            <Rate currency="CZK">0.2041</Rate>
+            <Rate currency="DKK">0.6625</Rate>
+            <Rate currency="EGP">0.1887</Rate>
+            <Rate currency="EUR">4.9273</Rate>
+            <Rate currency="GBP">5.5720</Rate>
+            <Rate currency="HUF" multiplier="100">1.2218</Rate>
+            <Rate currency="INR">0.0564</Rate>
+            <Rate currency="JPY" multiplier="100">3.5797</Rate>
+            <Rate currency="KRW" multiplier="100">0.3656</Rate>
+            <Rate currency="MDL">0.2407</Rate>
+            <Rate currency="MXN">0.2396</Rate>
+            <Rate currency="NOK">0.4701</Rate>
+            <Rate currency="NZD">2.9077</Rate>
+            <Rate currency="PLN">1.0518</Rate>
+            <Rate currency="RSD">0.0420</Rate>
+            <Rate currency="RUB">0.0641</Rate>
+            <Rate currency="SEK">0.4434</Rate>
+            <Rate currency="THB">0.1358</Rate>
+            <Rate currency="TRY">0.2496</Rate>
+            <Rate currency="UAH">0.1266</Rate>
+            <Rate currency="USD">4.6766</Rate>
+            <Rate currency="XAU">275.9130</Rate>
+            <Rate currency="XDR">6.2220</Rate>
+            <Rate currency="ZAR">0.2737</Rate>
+        </Cube>
+    </Body>

--- a/tests/data/bnr-sample-missing-symbols.json
+++ b/tests/data/bnr-sample-missing-symbols.json
@@ -1,5 +1,6 @@
 [
   {
-    "type": "bnr-fx-rate"
+    "type": "bnr-fx-rate",
+    "symbols": ["ABC"]
   }
 ]

--- a/tests/data/bnr-sample-missing-symbols.json
+++ b/tests/data/bnr-sample-missing-symbols.json
@@ -1,0 +1,5 @@
+[
+  {
+    "type": "bnr-fx-rate"
+  }
+]

--- a/tests/data/bnr-sample-no-symbols.json
+++ b/tests/data/bnr-sample-no-symbols.json
@@ -1,0 +1,5 @@
+[
+  {
+    "type": "bnr-fx-rate"
+  }
+]

--- a/tests/data/bnr-sample.json
+++ b/tests/data/bnr-sample.json
@@ -1,6 +1,6 @@
 [
   {
     "type": "bnr-fx-rate",
-    "symbols": ["EUR", "USD"]
+    "symbol": "EUR"
   }
 ]

--- a/tests/data/bnr-sample.json
+++ b/tests/data/bnr-sample.json
@@ -1,5 +1,6 @@
 [
   {
-    "type": "bnr-fx-rate"
+    "type": "bnr-fx-rate",
+    "symbols": ["EUR", "USD"]
   }
 ]

--- a/tests/data/bnr-sample.json
+++ b/tests/data/bnr-sample.json
@@ -1,0 +1,5 @@
+[
+  {
+    "type": "bnr-fx-rate"
+  }
+]

--- a/tests/invoice_utils/engine/test_bnr_fx_rates.py
+++ b/tests/invoice_utils/engine/test_bnr_fx_rates.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -85,9 +85,12 @@ def test_engine_bnr_rule_no_symbols_no_exchange_rates(engine, invoiced_item, bnr
     assert result["header"]["currency"]["exchangeRates"] == {}
 
 
-def test_engine_bnr_rule_adds_exchange_rates_for_symbols(engine, invoiced_item, bnr_res):
+@pytest.mark.parametrize(
+    "invoice_date", [TEST_INVOICE_DATE, datetime(2011, 11, 12), datetime(2011, 11, 13)]
+)
+def test_engine_bnr_rule_adds_exchange_rates_for_symbols(engine, invoiced_item, bnr_res, invoice_date):
     result = engine.process(
-        TEST_INVOICE_NUMBER, TEST_INVOICE_DATE, [invoiced_item]
+        TEST_INVOICE_NUMBER, invoice_date, [invoiced_item]
     )
 
     assert len(result["header"]["currency"]["exchangeRates"]) == 2

--- a/tests/invoice_utils/engine/test_bnr_fx_rates.py
+++ b/tests/invoice_utils/engine/test_bnr_fx_rates.py
@@ -65,18 +65,18 @@ def test_engine_does_not_call_bnr(engine, invoiced_item, responses):
     ) is True
 
 
-def test_engine_with_bnr_rule_makes_ron_the_main_currency(engine, invoiced_item, bnr_res):
+def test_engine_with_bnr_rule_makes_sets_specified_main_currency(engine, invoiced_item, bnr_res):
     result = engine.process(
         TEST_INVOICE_NUMBER, TEST_INVOICE_DATE, [invoiced_item]
     )
 
-    assert result["header"]["currency"]["main"] == "RON"
+    assert result["header"]["currency"]["main"] == "EUR"
 
 
 @pytest.mark.parametrize(
     "engine", ["bnr-sample-no-symbols.json", "bnr-sample-missing-symbols.json"], indirect=["engine"]
 )
-def test_engine_bnr_rule_no_symbols_no_exchange_rates(engine, invoiced_item, bnr_res):
+def test_engine_bnr_rule_no_main_symbol_no_exchange_rates(engine, invoiced_item, bnr_res):
     result = engine.process(
         TEST_INVOICE_NUMBER, TEST_INVOICE_DATE, [invoiced_item]
     )
@@ -93,10 +93,9 @@ def test_engine_bnr_rule_adds_exchange_rates_for_symbols(engine, invoiced_item, 
         TEST_INVOICE_NUMBER, invoice_date, [invoiced_item]
     )
 
-    assert len(result["header"]["currency"]["exchangeRates"]) == 2
+    assert len(result["header"]["currency"]["exchangeRates"]) == 1
     rates = result["header"]["currency"]["exchangeRates"]
-    assert rates["EUR"] == Decimal("4.9273")
-    assert rates["USD"] == Decimal("4.6766")
+    assert rates["RON"] == Decimal("4.9273")
 
 
 @pytest.mark.parametrize("bnr_res", ["bnr-response-invalid.xml"], indirect=["bnr_res"])

--- a/tests/invoice_utils/engine/test_bnr_fx_rates.py
+++ b/tests/invoice_utils/engine/test_bnr_fx_rates.py
@@ -66,3 +66,13 @@ def test_engine_with_bnr_rule_makes_ron_the_main_currency(engine, invoiced_item,
     )
 
     assert result["header"]["currency"]["main"] == "RON"
+
+
+@pytest.mark.parametrize("engine", ["bnr-sample-no-symbols.json"], indirect=["engine"])
+def test_engine_bnr_rule_no_symbols_no_exchange_rates(engine, invoiced_item, bnr_res):
+    result = engine.process(
+        TEST_INVOICE_NUMBER, TEST_INVOICE_DATE, [invoiced_item]
+    )
+
+    assert result["header"]["currency"]["main"] == "RON"
+    assert result["header"]["currency"]["exchangeRates"] == {}

--- a/tests/invoice_utils/engine/test_bnr_fx_rates.py
+++ b/tests/invoice_utils/engine/test_bnr_fx_rates.py
@@ -68,7 +68,9 @@ def test_engine_with_bnr_rule_makes_ron_the_main_currency(engine, invoiced_item,
     assert result["header"]["currency"]["main"] == "RON"
 
 
-@pytest.mark.parametrize("engine", ["bnr-sample-no-symbols.json"], indirect=["engine"])
+@pytest.mark.parametrize(
+    "engine", ["bnr-sample-no-symbols.json", "bnr-sample-missing-symbols.json"], indirect=["engine"]
+)
 def test_engine_bnr_rule_no_symbols_no_exchange_rates(engine, invoiced_item, bnr_res):
     result = engine.process(
         TEST_INVOICE_NUMBER, TEST_INVOICE_DATE, [invoiced_item]

--- a/tests/invoice_utils/engine/test_bnr_fx_rates.py
+++ b/tests/invoice_utils/engine/test_bnr_fx_rates.py
@@ -125,3 +125,19 @@ def test_engine_bnr_not_accessible_logs_error(
     assert result["header"]["currency"]["exchangeRates"] == {}
     assert caplog.messages[0] == "download error on BNR fx-rates"
     assert caplog.records[0].exc_info[1] == exception
+
+
+@pytest.mark.parametrize(
+    "invoice_date", [
+        datetime(2011, 11, 10),
+        datetime(2011, 11, 9),
+        datetime(2011, 11, 8),
+        datetime(2011, 11, 7),
+    ]
+)
+def test_engine_bnr_invoice_date_is_not_found(engine, invoiced_item, bnr_res, invoice_date, caplog):
+    with caplog.at_level("INFO"):
+        result = engine.process(TEST_INVOICE_NUMBER, invoice_date, [invoiced_item])
+
+    assert result["header"]["currency"]["exchangeRates"] == {}
+    assert caplog.messages[0] == f"can't find BNR fx rates for {invoice_date.strftime('%Y-%m-%d')}"

--- a/tests/invoice_utils/engine/test_bnr_fx_rates.py
+++ b/tests/invoice_utils/engine/test_bnr_fx_rates.py
@@ -107,3 +107,18 @@ def test_engine_bnr_rule_invalid_xml_response_logs_warning(
 
     assert result["header"]["currency"]["exchangeRates"] == {}
     assert caplog.messages[0] == "invalid XML downloaded from BNR"
+
+
+def test_engine_bnr_not_accessible_logs_error(
+    engine, invoiced_item, bnr_res, caplog
+):
+    exception = Exception()
+    bnr_res.body = exception
+    with caplog.at_level("ERROR"):
+        result = engine.process(
+            TEST_INVOICE_NUMBER, TEST_INVOICE_DATE, [invoiced_item]
+        )
+
+    assert result["header"]["currency"]["exchangeRates"] == {}
+    assert caplog.messages[0] == "download error on BNR fx-rates"
+    assert caplog.records[0].exc_info[1] == exception

--- a/tests/invoice_utils/engine/test_bnr_fx_rates.py
+++ b/tests/invoice_utils/engine/test_bnr_fx_rates.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from invoice_utils.engine import InvoicingEngine
+from invoice_utils.models import InvoicedItem
+
+
+@pytest.fixture
+def invoiced_item():
+    return InvoicedItem(
+        text="sample invoiced item",
+        quantity=Decimal("1.0"),
+        unit_price=Decimal("100.0")
+    )
+
+
+@pytest.fixture
+def invoice_date():
+    return datetime(2011, 11, 11)
+
+
+@pytest.fixture
+def bnr_sample_path(data_dir):
+    return str(data_dir / "bnr-sample.json")
+
+
+@pytest.fixture
+def engine(bnr_sample_path, request):
+    file_path = bnr_sample_path if not hasattr(request, "param") or request.param is None else request.param
+    return InvoicingEngine(file_path)
+
+
+def test_engine_loads_makes_call_to_bnr_for_invoice_date(
+    engine, invoice_date, invoiced_item, responses, read_text
+):
+    bnr_resp = responses.get(
+        "https://bnr.ro/files/xml/years/nbrfxrates2011.xml",
+        content_type="text/xml",
+        body=read_text("bnr-response-1-item.xml")
+    )
+    engine.process(12, invoice_date, [invoiced_item])
+
+    assert bnr_resp.call_count == 1
+    assert bnr_resp.status == 200

--- a/tests/invoice_utils/engine/test_bnr_fx_rates.py
+++ b/tests/invoice_utils/engine/test_bnr_fx_rates.py
@@ -76,3 +76,14 @@ def test_engine_bnr_rule_no_symbols_no_exchange_rates(engine, invoiced_item, bnr
 
     assert result["header"]["currency"]["main"] == "RON"
     assert result["header"]["currency"]["exchangeRates"] == {}
+
+
+def test_engine_bnr_rule_adds_exchange_rates_for_symbols(engine, invoiced_item, bnr_res):
+    result = engine.process(
+        TEST_INVOICE_NUMBER, TEST_INVOICE_DATE, [invoiced_item]
+    )
+
+    assert len(result["header"]["currency"]["exchangeRates"]) == 2
+    rates = result["header"]["currency"]["exchangeRates"]
+    assert rates["EUR"] == Decimal("4.9273")
+    assert rates["USD"] == Decimal("4.6766")


### PR DESCRIPTION
For currencies that are in currencies other than Romanian New Leu, allow using the BNR (National Bank of Romania) exchange rates to convert amounts to RON.